### PR TITLE
fix(labyrinth): one object, multiple properties

### DIFF
--- a/.changeset/afraid-games-think.md
+++ b/.changeset/afraid-games-think.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/labyrinth": patch
+---
+
+Operation would not be found if an object would have been used in multiple relations, if not all were supported properties

--- a/packages/labyrinth/test/lib/loader.test.ts
+++ b/packages/labyrinth/test/lib/loader.test.ts
@@ -44,7 +44,7 @@ describe('@hydrofoil/labbyrinth/lib/loader/SparqlQueryLoader', function () {
       graph ${ex.Leonard} {
         ${ex.Leonard} 
           ${rdf.type} ${schema.Person}, ${hydra.Resource} ;
-          ${foaf.knows} ${ex.Bernadette}, ${ex.Howard} ;
+          ${foaf.knows} ${ex.Bernadette}, ${ex.Howard}, ${ex.Penny} ;
           ${schema.spouse} ${ex.Penny} ;
           ${schema.name} "Leonard Hofstadter" ; 
       }
@@ -149,15 +149,32 @@ describe('@hydrofoil/labbyrinth/lib/loader/SparqlQueryLoader', function () {
       const term = ex.Bernadette
 
       // when
-      const resoruces = await loader.forPropertyOperation(term)
+      const resources = await loader.forPropertyOperation(term)
 
       // then
-      const subjects = resoruces.map(({ term }) => term.value)
+      const subjects = resources.map(({ term }) => term.value)
       expect(subjects).to.contain.all.members([
         ex.Sheldon.value,
         ex.Leonard.value,
         ex.Penny.value,
         ex.Howard.value,
+      ])
+    })
+
+    it('returns objects for usage of same object with multiple properties', async () => {
+      // given
+      const term = ex.Penny
+
+      // when
+      const resources = await loader.forPropertyOperation(term)
+
+      // then
+      const properties = resources.map(({ property }) => property)
+      expect(resources).to.containAll<PropertyResource>(({ term }) => term.equals(ex.Leonard))
+      expect(properties).to.have.length(2)
+      expect(properties).to.deep.contain.all.members([
+        foaf.knows,
+        schema.spouse,
       ])
     })
 


### PR DESCRIPTION
Handle the case when a object is used by multiple predicates and only some of them are supported properties

It was possible that some of them were getting lost, depending on their order in the SPARQL response.