### PR TITLE
fix: filter out terms from other APIs

### DIFF
--- a/.changeset/flat-dolls-wink.md
+++ b/.changeset/flat-dolls-wink.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/knossos": patch
+---
+
+Multi-tenancy: ApiDocumentation terms leak between APIs

--- a/packages/knossos/lib/query.ts
+++ b/packages/knossos/lib/query.ts
@@ -6,16 +6,14 @@ import { hydra } from '@tpluscode/rdf-ns-builders'
 export function loadClasses(api: NamedNode, client: StreamClient): Promise<Stream> {
   return DESCRIBE`?c ?sp ?op ?p`
     .WHERE`
-    BIND ( ${api} as ?api ) .
-    
     {
-      ?c a ${hydra.Class} ; ${hydra.apiDocumentation} ?api.
+      ?c a ${hydra.Class} ; ${hydra.apiDocumentation} ${api}.
     } union {
       ?c a ${hydra.Class} ; ${hydra.supportedOperation} ?op .
       
       FILTER (
-        EXISTS { ?c ${hydra.apiDocumentation} ?api } ||
-        EXISTS { ?op ${hydra.apiDocumentation} ?api }
+        EXISTS { ?c ${hydra.apiDocumentation} ${api} } ||
+        EXISTS { ?op ${hydra.apiDocumentation} ${api} }
       )
     } union {
       ?c ${hydra.supportedProperty} ?sp .
@@ -23,9 +21,9 @@ export function loadClasses(api: NamedNode, client: StreamClient): Promise<Strea
       ?p ${hydra.supportedOperation} ?op .
  
       FILTER (
-        EXISTS { ?c ${hydra.apiDocumentation} ?api } ||
-        EXISTS { ?sp ${hydra.apiDocumentation} ?api } ||
-        EXISTS { ?op ${hydra.apiDocumentation} ?api }
+        EXISTS { ?c ${hydra.apiDocumentation} ${api} } ||
+        EXISTS { ?sp ${hydra.apiDocumentation} ${api} } ||
+        EXISTS { ?op ${hydra.apiDocumentation} ${api} }
       )
     }
     `


### PR DESCRIPTION
When multiple APIs are running from same store, the `ApiDocumentation` resource would incorrectly combine all supported classes from all APIs