### PR TITLE
Include all classes in ApiDocumentation

### DIFF
--- a/.changeset/large-rivers-worry.md
+++ b/.changeset/large-rivers-worry.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/knossos": patch
+---
+
+Supported operations should also be loaded when class is not explicitly `hydra:Class`

--- a/packages/knossos/lib/query.ts
+++ b/packages/knossos/lib/query.ts
@@ -9,7 +9,7 @@ export function loadClasses(api: NamedNode, client: StreamClient): Promise<Strea
     {
       ?c a ${hydra.Class} ; ${hydra.apiDocumentation} ${api}.
     } union {
-      ?c a ${hydra.Class} ; ${hydra.supportedOperation} ?op .
+      ?c ${hydra.supportedOperation} ?op .
       
       FILTER (
         EXISTS { ?c ${hydra.apiDocumentation} ${api} } ||

--- a/packages/knossos/package.json
+++ b/packages/knossos/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@labyrinth/testing": "^0.0.1",
-    "@tpluscode/rdfine": "^0.5.25",
     "@types/camouflage-rewrite": "^1.2.0",
     "@types/fcostarodrigo__walk": "^5.0.1",
     "@types/fs-extra": "^9.0.10",

--- a/packages/knossos/test/lib/query.test.ts
+++ b/packages/knossos/test/lib/query.test.ts
@@ -23,6 +23,27 @@ describe('@hydrofoil/knossos/lib/query', () => {
       expect(clas.out().values).to.have.length.greaterThan(0)
     })
 
+    it('finds non-Hydra classes which have operations', async () => {
+      // given
+      await testData(sparql`
+        ${ex.Class} ${hydra.supportedOperation} [
+          ${hydra.apiDocumentation} ${ex.api}
+        ] .
+       
+        ${ex.Class2} ${hydra.apiDocumentation} ${ex.api} .
+        ${ex.Class2} ${hydra.supportedOperation} [] .
+      `)
+
+      // when
+      const dataset = await $rdf.dataset().import(await loadClasses(ex.api, client))
+
+      // then
+      const classes = clownface({ dataset }).has(hydra.supportedOperation)
+      expect(classes.terms).to.deep.contain.members([
+        ex.Class, ex.Class2,
+      ])
+    })
+
     it('loads operations supported by properties', async () => {
       // given
       await testData(sparql`


### PR DESCRIPTION
Any resource which is subject of `hydra:supportedOperation` should be included in the API Documentation